### PR TITLE
fix: allowed the '-' character in MeasurementInfo

### DIFF
--- a/RueI/RueI/Parsing/Records/MeasurementInfo.cs
+++ b/RueI/RueI/Parsing/Records/MeasurementInfo.cs
@@ -53,7 +53,7 @@ public record struct MeasurementInfo(float value, MeasurementUnit style)
                     paramBuffer.Append('.');
                 }
             }
-            else if (char.IsDigit(ch))
+            else if (char.IsDigit(ch) || ch == '-')
             {
                 paramBuffer.Append(ch);
             }


### PR DESCRIPTION
Negative numbers were not possible for any of the tags. This Pull Request fixes that by allowing them.
Why would you need it? the <pos=x> accepts negative numbers